### PR TITLE
Async actioncommand

### DIFF
--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -14,10 +14,12 @@
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<OutputPath>..\bin\Debug\</OutputPath>
+		<LangVersion>8</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
 		<DebugType>none</DebugType>
 		<OutputPath>..\bin\Release\</OutputPath>
+		<LangVersion>8</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<Resource Include="Syn3Updater Logo Cropped.png" />
@@ -25,7 +27,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentWPF" Version="0.9.0" />
-		<PackageReference Include="ModernWpf.MessageBox" Version="0.4.2" />
+		<PackageReference Include="ModernWpf.MessageBox" Version="0.5.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="Octokit" Version="0.50.0" />
 		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.212405">

--- a/SharedCode/Methods/JsonHelpers.cs
+++ b/SharedCode/Methods/JsonHelpers.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System.IO;
+
+namespace Cyanlabs.Updater.Common
+{
+    public static class JsonHelpers
+    {
+        public static T Deserialize<T>(Stream s)
+        {
+            using StreamReader reader = new StreamReader(s);
+            using JsonTextReader jsonReader = new JsonTextReader(reader);
+            JsonSerializer ser = new JsonSerializer();
+            return ser.Deserialize<T>(jsonReader);
+        }
+
+        public static void Serialize(object value, Stream s)
+        {
+            using StreamWriter writer = new StreamWriter(s);
+            using JsonTextWriter jsonWriter = new JsonTextWriter(writer);
+            JsonSerializer ser = new JsonSerializer();
+            ser.Serialize(jsonWriter, value);
+            jsonWriter.Flush();
+        }
+    }
+}

--- a/SharedCode/SharedCode.projitems
+++ b/SharedCode/SharedCode.projitems
@@ -8,6 +8,7 @@
   <PropertyGroup Label="Configuration" />
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Classes\LauncherPrefs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Methods\JsonHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Classes\" />

--- a/Syn3Updater/Helper/ApiHelper.cs
+++ b/Syn3Updater/Helper/ApiHelper.cs
@@ -18,8 +18,8 @@ namespace Cyanlabs.Syn3Updater.Helper
         /// <param name="url">URL of a valid 'SpecialPackage'</param>
         public async static Task<SModel.Ivsu> GetSpecialIvsu(string url)
         {
-            HttpResponseMessage response = await ApplicationManager.Instance.Client.GetAsync(url);     
-            return ConvertIvsu(JsonHelpers.Deserialize<Api.Ivsu>(await response.Content.ReadAsStreamAsync()));
+            HttpResponseMessage response = await ApplicationManager.Instance.Client.GetAsync(url).ConfigureAwait(false);
+            return ConvertIvsu(JsonHelpers.Deserialize<Api.Ivsu>(await response.Content.ReadAsStreamAsync().ConfigureAwait(false)));
         }
 
         /// <summary>

--- a/Syn3Updater/Helper/ApiHelper.cs
+++ b/Syn3Updater/Helper/ApiHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using Cyanlabs.Syn3Updater.Model;
+using Cyanlabs.Updater.Common;
 using Newtonsoft.Json;
 
 namespace Cyanlabs.Syn3Updater.Helper
@@ -14,11 +16,10 @@ namespace Cyanlabs.Syn3Updater.Helper
         ///     Get special IVSU package such as Downgrade or Reformat from our API and passes it to ConvertIvsu
         /// </summary>
         /// <param name="url">URL of a valid 'SpecialPackage'</param>
-        public static SModel.Ivsu GetSpecialIvsu(string url)
+        public async static Task<SModel.Ivsu> GetSpecialIvsu(string url)
         {
-            HttpResponseMessage response = ApplicationManager.Instance.Client.GetAsync(url).Result;
-            Api.Ivsu ivsu = JsonConvert.DeserializeObject<Api.Ivsu>(response.Content.ReadAsStringAsync().Result);
-            return ConvertIvsu(ivsu);
+            HttpResponseMessage response = await ApplicationManager.Instance.Client.GetAsync(url);     
+            return ConvertIvsu(JsonHelpers.Deserialize<Api.Ivsu>(await response.Content.ReadAsStreamAsync()));
         }
 
         /// <summary>

--- a/Syn3Updater/Helper/FileHelper.cs
+++ b/Syn3Updater/Helper/FileHelper.cs
@@ -134,7 +134,7 @@ namespace Cyanlabs.Syn3Updater.Helper
                             return;
                         }
 
-                        int read = await stream.ReadAsync(buffer, 0, buffer.Length, ct);
+                        int read = await stream.ReadAsync(buffer, 0, buffer.Length, ct).ConfigureAwait(false);
 
                         if (read == 0)
                         {

--- a/Syn3Updater/Syn3Updater.csproj
+++ b/Syn3Updater/Syn3Updater.csproj
@@ -52,7 +52,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
 		<PackageReference Include="QRCoder" Version="1.4.1" />
-		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="5.1.0" />	
+		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="5.1.0" />
+		<PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
 		<!-- Only needed for netframework-->
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.212405">

--- a/Syn3Updater/Syn3Updater.csproj
+++ b/Syn3Updater/Syn3Updater.csproj
@@ -48,10 +48,11 @@
 		<PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
 		<PackageReference Include="SharpZipLib" Version="1.3.1" />
 		<PackageReference Include="System.Management" Version="5.0.0" />
-		<PackageReference Include="ModernWpf.MessageBox" Version="0.4.2" />
+		<PackageReference Include="ModernWpf.MessageBox" Version="0.5.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="3.1.0" />
 		<PackageReference Include="QRCoder" Version="1.4.1" />
+		<PackageReference Include="AsyncAwaitBestPractices.MVVM" Version="5.1.0" />	
 		<!-- Only needed for netframework-->
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.2.212405">

--- a/Syn3Updater/UI/Tabs/DownloadViewModel.cs
+++ b/Syn3Updater/UI/Tabs/DownloadViewModel.cs
@@ -121,7 +121,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             PercentageChanged += DownloadPercentageChanged;
 
             DownloadQueueList = new ObservableCollection<string>();
-            foreach (SModel.Ivsu item in ApplicationManager.Instance.Ivsus) DownloadQueueList.Add(item.Url);
+            foreach (SModel.Ivsu item in ApplicationManager.Instance.Ivsus) 
+                DownloadQueueList.Add(item.Url);
 
             _ct = _tokenSource.Token;
 
@@ -137,7 +138,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                }
 
                if (t.IsCompleted && !t.IsFaulted)
-                   await DownloadComplete();
+                   await DownloadComplete().ConfigureAwait(false);
            }, _tokenSource.Token);
         }
 

--- a/Syn3Updater/UI/Tabs/DownloadViewModel.cs
+++ b/Syn3Updater/UI/Tabs/DownloadViewModel.cs
@@ -127,7 +127,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
 
             _fileHelper = new FileHelper(PercentageChanged);
 
-            _downloadTask = Task.Run(DoDownload, _tokenSource.Token).ContinueWith(t =>
+            _downloadTask = Task.Run(DoDownload, _tokenSource.Token).ContinueWith(async t =>
            {
                if (t.IsFaulted)
                {
@@ -137,7 +137,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                }
 
                if (t.IsCompleted && !t.IsFaulted)
-                   DownloadComplete();
+                   await DownloadComplete();
            }, _tokenSource.Token);
         }
 
@@ -155,20 +155,20 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     return;
                 }
 
-                if (ValidateFile(item.Url, ApplicationManager.Instance.DownloadPath + item.FileName, item.Md5, false, true))
+                if (await ValidateFile(item.Url, ApplicationManager.Instance.DownloadPath + item.FileName, item.Md5, false, true).ConfigureAwait(false))
                 {
                     string text = $"Validated: {item.FileName} (Skipping Download)";
                     Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
                     ApplicationManager.Logger.Info(text);
-                    
+
                     if (item.Source == "naviextras")
                     {
                         FileHelper.OutputResult outputResult = _fileHelper.ExtractMultiPackage(item, _ct);
-                        
+
                         text = $"Extracting: {item.FileName} (This may take some time!)";
                         Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
                         ApplicationManager.Logger.Info(text);
-                        
+
                         if (outputResult.Result)
                         {
                             Log += "[" + DateTime.Now + "] " + outputResult.Message + Environment.NewLine;
@@ -223,19 +223,19 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                                 CancelAction();
                             }
 
-                            if (ValidateFile(item.Url, ApplicationManager.Instance.DownloadPath + item.FileName, item.Md5, false))
+                            if (await ValidateFile(item.Url, ApplicationManager.Instance.DownloadPath + item.FileName, item.Md5, false).ConfigureAwait(false))
                             {
                                 text = $"Downloaded: {item.FileName}";
                                 Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
                                 ApplicationManager.Logger.Info(text);
                                 if (item.Source == "naviextras")
                                 {
-                                    FileHelper.OutputResult outputResult = _fileHelper.ExtractMultiPackage(item,_ct);
-                        
+                                    FileHelper.OutputResult outputResult = _fileHelper.ExtractMultiPackage(item, _ct);
+
                                     text = $"Extracting: {item.FileName} (This may take some time!)";
                                     Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
                                     ApplicationManager.Logger.Info(text);
-                        
+
                                     if (outputResult.Result)
                                     {
                                         Log += "[" + DateTime.Now + "] " + outputResult.Message + Environment.NewLine;
@@ -274,7 +274,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             Application.Current.Dispatcher.Invoke(() => { DownloadQueueList.Clear(); });
         }
 
-        private void DownloadComplete()
+        private async Task DownloadComplete()
         {
             if (!_ct.IsCancellationRequested)
             {
@@ -292,7 +292,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                 }
                 else
                 {
-                    PrepareUsb();
+                    await PrepareUsbAsync().ConfigureAwait(false);
                 }
             }
         }
@@ -318,8 +318,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     _count++;
                     continue;
                 }
-                if (ValidateFile(ApplicationManager.Instance.DownloadPath + item.FileName, $@"{ApplicationManager.Instance.DriveLetter}\SyncMyRide\{item.FileName}", item.Md5,
-                    true, true))
+                if (await ValidateFile(ApplicationManager.Instance.DownloadPath + item.FileName, $@"{ApplicationManager.Instance.DriveLetter}\SyncMyRide\{item.FileName}", item.Md5,
+                    true, true).ConfigureAwait(false))
                 {
                     string text = $"{item.FileName} exists and validated successfully, skipping copy";
                     Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
@@ -375,8 +375,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                             CancelAction();
                         }
 
-                        if (ValidateFile(ApplicationManager.Instance.DownloadPath + item.FileName,
-                            $@"{ApplicationManager.Instance.DriveLetter}\SyncMyRide\{item.FileName}", item.Md5, true))
+                        if (await ValidateFile(ApplicationManager.Instance.DownloadPath + item.FileName,
+                            $@"{ApplicationManager.Instance.DriveLetter}\SyncMyRide\{item.FileName}", item.Md5, true).ConfigureAwait(false))
                         {
                             text = $"Copied: {item.FileName}";
                             Log += "[" + DateTime.Now + "] " + text + Environment.NewLine;
@@ -437,14 +437,15 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
 
             DownloadInfo = LanguageManager.GetValue("String.Completed");
             ApplicationManager.Instance.IsDownloading = false;
+
             Application.Current.Dispatcher.Invoke(() =>
             {
                 USBHelper.GenerateLog(Log, ModernWpf.MessageBox.Show(LanguageManager.GetValue("MessageBox.UploadLog"), "Syn3 Updater", MessageBoxButton.YesNo,
-                    MessageBoxImage.Information) == MessageBoxResult.Yes);
+                MessageBoxImage.Information) == MessageBoxResult.Yes);
 
                 if (_action == "main")
                 {
-                    if (ModernWpf.MessageBox.Show(string.Format(LanguageManager.GetValue("MessageBox.UpdateCurrentversion"),ApplicationManager.Instance.SVersion,ApplicationManager.Instance.SelectedRelease.Replace("Sync ", "")), "Syn3 Updater", MessageBoxButton.YesNo,
+                    if (ModernWpf.MessageBox.Show(string.Format(LanguageManager.GetValue("MessageBox.UpdateCurrentversion"), ApplicationManager.Instance.SVersion, ApplicationManager.Instance.SelectedRelease.Replace("Sync ", "")), "Syn3 Updater", MessageBoxButton.YesNo,
                         MessageBoxImage.Information) == MessageBoxResult.Yes)
                     {
                         ApplicationManager.Instance.Settings.CurrentVersion =
@@ -476,6 +477,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     ModernWpf.MessageBox.Show(LanguageManager.GetValue("MessageBox.GenericUtilityComplete"), "Syn3 Updater", MessageBoxButton.OK, MessageBoxImage.Information);
                     ApplicationManager.Instance.FireUtilityTabEvent();
                 }
+
             });
             Reset();
         }
@@ -520,7 +522,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             TotalPercentage = _count == 0 ? e.Value : (_count * 100) + e.Value;
         }
 
-        private void PrepareUsb()
+        private async Task PrepareUsbAsync()
         {
             if (ApplicationManager.Instance.DownloadToFolder)
             {
@@ -570,12 +572,12 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     Thread.Sleep(5000);
                 }
             }
-            
+
             foreach (SModel.Ivsu item in ApplicationManager.Instance.Ivsus)
                 Application.Current.Dispatcher.Invoke(() => DownloadQueueList.Add(ApplicationManager.Instance.DownloadPath + item.FileName));
 
             Directory.CreateDirectory($@"{ApplicationManager.Instance.DriveLetter}\SyncMyRide\");
-            Task.Run(DoCopy, _tokenSource.Token).ContinueWith(t =>
+            await DoCopy().ContinueWith(t =>
             {
                 if (t.IsFaulted)
                 {
@@ -584,8 +586,10 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     CancelAction();
                 }
 
-                if (t.IsCompleted && !t.IsFaulted) CopyComplete();
-            }, _tokenSource.Token);
+                if (t.IsCompleted && !t.IsFaulted)
+                    CopyComplete();
+            }, _tokenSource.Token).ConfigureAwait(false);
+
         }
 
         private void CreateAutoInstall()
@@ -661,7 +665,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
 
             var autoinstalllst = new StringBuilder(
                 $@"; CyanLabs Syn3Updater 2.x - {InstallMode} Mode - {_selectedRelease} {_selectedRegion}{Environment.NewLine}{Environment.NewLine}[SYNCGen3.0_ALL_PRODUCT]{Environment.NewLine}");
-            if (InstallMode == @"downgrade")
+            if (InstallMode == "downgrade")
             {
                 autoinstalllst.Append(
                     $@"Item1 = TOOL - {Api.DowngradeTool.FileName}\rOpen1 = SyncMyRide\{Api.DowngradeTool.FileName}\r").Replace(@"\r",
@@ -683,7 +687,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             File.Create($@"{ApplicationManager.Instance.DriveLetter}\DONTINDX.MSA");
         }
 
-        private bool ValidateFile(string srcfile, string localfile, string md5, bool copy, bool existing = false)
+        private async Task<bool> ValidateFile(string srcfile, string localfile, string md5, bool copy, bool existing = false)
         {
             string text = $"Validating: {Path.GetFileName(localfile)}";
             if (existing) text = $"Checking Existing File: {Path.GetFileName(localfile)}";
@@ -692,7 +696,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Logger.Info(text);
 
             _progressBarSuffix = LanguageManager.GetValue("String.Validated");
-            FileHelper.OutputResult outputResult = _fileHelper.ValidateFile(srcfile, localfile, md5, copy, _ct);
+            FileHelper.OutputResult outputResult = await _fileHelper.ValidateFile(srcfile, localfile, md5, copy, _ct).ConfigureAwait(false);
 
             if (outputResult.Message != "")
             {

--- a/Syn3Updater/UI/Tabs/HomeViewModel.cs
+++ b/Syn3Updater/UI/Tabs/HomeViewModel.cs
@@ -5,8 +5,10 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Markup;
+using AsyncAwaitBestPractices.MVVM;
 using Cyanlabs.Syn3Updater.Helper;
 using Cyanlabs.Syn3Updater.Model;
 using Newtonsoft.Json;
@@ -18,12 +20,12 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
     {
         #region Constructors
 
-        private ActionCommand _startButton;
+        private AsyncCommand _startButton;
         private ActionCommand _refreshUSB;
         private ActionCommand _regionInfo;
         public ActionCommand RefreshUSB => _refreshUSB ??= new ActionCommand(RefreshUsb);
         public ActionCommand RegionInfo => _regionInfo ??= new ActionCommand(RegionInfoAction);
-        public ActionCommand StartButton => _startButton ??= new ActionCommand(StartAction);
+        public AsyncCommand StartButton => _startButton ??= new AsyncCommand(StartAction);
 
         #endregion
 
@@ -89,7 +91,10 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             set
             {
                 SetProperty(ref _selectedRelease, value);
-                if (value != null) UpdateSelectedRelease();
+                if (value != null)
+                {
+                    UpdateSelectedRelease();
+                }
             }
         }
 
@@ -101,7 +106,10 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             set
             {
                 SetProperty(ref _selectedMapVersion, value);
-                if (value != null) UpdateSelectedMapVersion();
+                if (value != null)
+                {
+                    UpdateSelectedMapVersion();
+                }
             }
         }
 
@@ -580,7 +588,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             }
         }
 
-        private void StartAction()
+        private async Task StartAction()
         {
             ApplicationManager.Logger.Info(
                 $"USB Drive selected - Name: {ApplicationManager.Instance.DriveName} - FileSystem: {ApplicationManager.Instance.DriveFileSystem} - PartitionType: {ApplicationManager.Instance.DrivePartitionType} - Letter: {DriveLetter}");
@@ -588,16 +596,16 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
 
             if (InstallMode == "downgrade")
             {
-                Api.DowngradeApp = ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp);
+                Api.DowngradeApp =  await ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp);
                 ApplicationManager.Instance.Ivsus.Add(Api.DowngradeApp);
 
-                Api.DowngradeTool = ApiHelper.GetSpecialIvsu(Api.GetDowngradeTool);
+                Api.DowngradeTool = await ApiHelper.GetSpecialIvsu(Api.GetDowngradeTool);
                 ApplicationManager.Instance.Ivsus.Add(Api.DowngradeTool);
             }
 
             if (InstallMode == "reformat" || InstallMode == "downgrade")
             {
-                Api.ReformatTool = ApiHelper.GetSpecialIvsu(Api.GetReformat);
+                Api.ReformatTool = await ApiHelper.GetSpecialIvsu(Api.GetReformat);
                 ApplicationManager.Instance.Ivsus.Add(Api.ReformatTool);
             }
 

--- a/Syn3Updater/UI/Tabs/UtilityViewModel.cs
+++ b/Syn3Updater/UI/Tabs/UtilityViewModel.cs
@@ -15,6 +15,7 @@ using System.Xml.Linq;
 using AsyncAwaitBestPractices.MVVM;
 using Cyanlabs.Syn3Updater.Helper;
 using Cyanlabs.Syn3Updater.Model;
+using Cyanlabs.Updater.Common;
 using Newtonsoft.Json;
 using Ookii.Dialogs.Wpf;
 using Formatting = Newtonsoft.Json.Formatting;
@@ -34,17 +35,17 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
         private AsyncCommand _logPrepareUSB;
         public AsyncCommand LogPrepareUSB => _logPrepareUSB ??= new AsyncCommand(LogPrepareUSBAction);
 
-        private ActionCommand _logParseXml;
-        public ActionCommand LogParseXml => _logParseXml ??= new ActionCommand(LogParseXmlAction);
+        private AsyncCommand _logParseXml;
+        public AsyncCommand LogParseXml => _logParseXml ??= new AsyncCommand(LogParseXmlAction);
 
-        private ActionCommand _gracenotesRemovalUSB;
-        public ActionCommand GracenotesRemovalUSB => _gracenotesRemovalUSB ??= new ActionCommand(GracenotesRemovalAction);
+        private AsyncCommand _gracenotesRemovalUSB;
+        public AsyncCommand GracenotesRemovalUSB => _gracenotesRemovalUSB ??= new AsyncCommand(GracenotesRemovalAction);
 
-        private ActionCommand _smallVoiceUSB;
-        public ActionCommand SmallVoiceUSB => _smallVoiceUSB ??= new ActionCommand(SmallVoiceAction);
+        private AsyncCommand _smallVoiceUSB;
+        public AsyncCommand SmallVoiceUSB => _smallVoiceUSB ??= new AsyncCommand(SmallVoiceAction);
 
-        private ActionCommand _downgradeUSB;
-        public ActionCommand DowngradeUSB => _downgradeUSB ??= new ActionCommand(DowngradeAction);
+        private AsyncCommand _downgradeUSB;
+        public AsyncCommand DowngradeUSB => _downgradeUSB ??= new AsyncCommand(DowngradeAction);
 
         private ActionCommand _troubleshootingDetails;
         public ActionCommand TroubleshootingDetails => _troubleshootingDetails ??= new ActionCommand(TroubleshootingDetailsAction);
@@ -227,13 +228,14 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
 
         private ApimDetails _apimDetails;
 
-        private void LogParseXmlAction()
+        private async Task LogParseXmlAction()
         {
             VistaFileDialog dialog = new VistaOpenFileDialog { Filter = "Interrogator Log XML Files|*.xml" };
             if (dialog.ShowDialog().GetValueOrDefault())
                 try
                 {
                     XmlDocument doc = new XmlDocument();
+                    //TODO: swtich to Async once code moves to dotnet 5+ 
                     doc.Load(dialog.FileName);
                     string json = JsonConvert.SerializeXmlNode(doc, Formatting.Indented);
                     Interrogator.InterrogatorModel interrogatorLog = JsonConvert.DeserializeObject<Interrogator.InterrogatorModel>(json);
@@ -306,8 +308,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                         Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ApiSecret.Token);
                         try
                         {
-                            HttpResponseMessage response = Client.GetAsync(Api.IvsuSingle + sappname).Result;
-                            Api.JsonReleases sversion = JsonConvert.DeserializeObject<Api.JsonReleases>(response.Content.ReadAsStringAsync().Result);
+                            HttpResponseMessage response = await Client.GetAsync(Api.IvsuSingle + sappname);
+                            Api.JsonReleases sversion = JsonHelpers.Deserialize<Api.JsonReleases>(await response.Content.ReadAsStreamAsync());
                             string convertedsversion = sversion.Releases[0].Version.Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
                             if (convertedsversion != ApplicationManager.Instance.SVersion)
                                 if (ModernWpf.MessageBox.Show(string.Format(LanguageManager.GetValue("MessageBox.UpdateCurrentVersionUtility"),ApplicationManager.Instance.SVersion, convertedsversion),
@@ -363,14 +365,14 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                         new KeyValuePair<string, string>("size", _apimDetails.Size.ToString()),
                         new KeyValuePair<string, string>("vin", _apimDetails.VIN)
                     });
-                    HttpResponseMessage response = await Client.PostAsync(Api.AsBuiltPost, formContent).ConfigureAwait(false);              
+                    HttpResponseMessage response = await Client.PostAsync(Api.AsBuiltPost, formContent).ConfigureAwait(false);             
                     string contents = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     var output = JsonConvert.DeserializeAnonymousType(contents, new { filename = "", status = "" });
                     Process.Start(Api.AsBuiltOutput + output.filename);
                 }
         }
 
-        private void GracenotesRemovalAction()
+        private async Task GracenotesRemovalAction()
         {
             //Reset ApplicationManager variables
             ApplicationManager.Instance.Ivsus.Clear();
@@ -378,7 +380,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.DriveLetter = DriveLetter;
             ApplicationManager.Instance.Action = "gracenotesremoval";
             ApplicationManager.Instance.SelectedRelease = "Gracenotes Removal";
-            Api.GracenotesRemoval = ApiHelper.GetSpecialIvsu(Api.GetGracenotesRemoval).GetAwaiter().GetResult();
+            //don't call ConfigureAwait(false) here either 
+            Api.GracenotesRemoval = await ApiHelper.GetSpecialIvsu(Api.GetGracenotesRemoval);
             ApplicationManager.Instance.Ivsus.Add(Api.GracenotesRemoval);
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"
                 ? "autoinstall"
@@ -392,7 +395,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.FireDownloadsTabEvent();
         }
 
-        private void SmallVoiceAction()
+        private async Task SmallVoiceAction()
         {
             //Reset ApplicationManager variables
             ApplicationManager.Instance.Ivsus.Clear();
@@ -401,7 +404,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.Action = "voiceshrinker";
             ApplicationManager.Instance.SelectedRelease = "Voice Package Shrinker";
 
-            Api.SmallVoicePackage = ApiHelper.GetSpecialIvsu(Api.GetSmallVoice).GetAwaiter().GetResult();
+            Api.SmallVoicePackage = await ApiHelper.GetSpecialIvsu(Api.GetSmallVoice);
             ApplicationManager.Instance.Ivsus.Add(Api.SmallVoicePackage);
 
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"
@@ -416,7 +419,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.FireDownloadsTabEvent();
         }
 
-        private void DowngradeAction()
+        private async Task DowngradeAction()
         {
             //Reset ApplicationManager variables
             ApplicationManager.Instance.Ivsus.Clear();
@@ -424,7 +427,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.DriveLetter = DriveLetter;
             ApplicationManager.Instance.Action = "downgrade";
             ApplicationManager.Instance.SelectedRelease = "Enforced Downgrade";
-            Api.DowngradeApp = ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp).GetAwaiter().GetResult();
+            Api.DowngradeApp = await ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp);
             ApplicationManager.Instance.Ivsus.Add(Api.DowngradeApp);
 
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"

--- a/Syn3Updater/UI/Tabs/UtilityViewModel.cs
+++ b/Syn3Updater/UI/Tabs/UtilityViewModel.cs
@@ -7,10 +7,12 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Markup;
 using System.Xml;
 using System.Xml.Linq;
+using AsyncAwaitBestPractices.MVVM;
 using Cyanlabs.Syn3Updater.Helper;
 using Cyanlabs.Syn3Updater.Model;
 using Newtonsoft.Json;
@@ -29,8 +31,8 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
         private ActionCommand _refreshUSB;
         public ActionCommand RefreshUSB => _refreshUSB ??= new ActionCommand(RefreshUsbAction);
 
-        private ActionCommand _logPrepareUSB;
-        public ActionCommand LogPrepareUSB => _logPrepareUSB ??= new ActionCommand(LogPrepareUSBAction);
+        private AsyncCommand _logPrepareUSB;
+        public AsyncCommand LogPrepareUSB => _logPrepareUSB ??= new AsyncCommand(LogPrepareUSBAction);
 
         private ActionCommand _logParseXml;
         public ActionCommand LogParseXml => _logParseXml ??= new ActionCommand(LogParseXmlAction);
@@ -179,7 +181,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
                     $"USB Drive selected - Name: {driveInfo.Name} - FileSystem: {driveInfo.FileSystem} - PartitionType: {driveInfo.PartitionType} - Letter: {driveInfo.Letter}");
         }
 
-        private void LogPrepareUSBAction()
+        private async Task LogPrepareUSBAction()
         {
             //Reset ApplicationManager variables
             ApplicationManager.Instance.Ivsus.Clear();
@@ -190,13 +192,13 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             
             string currentversion = ApplicationManager.Instance.SVersion;
             if (currentversion.StartsWith("3.4"))
-                Api.InterrogatorTool = ApiHelper.GetSpecialIvsu(Api.GetLogTool34);
+                Api.InterrogatorTool = await ApiHelper.GetSpecialIvsu(Api.GetLogTool34).ConfigureAwait(false);
             else if (currentversion.StartsWith("3.2") || currentversion.StartsWith("3.3"))
-                Api.InterrogatorTool = ApiHelper.GetSpecialIvsu(Api.GetLogTool32);
+                Api.InterrogatorTool = await ApiHelper.GetSpecialIvsu(Api.GetLogTool32).ConfigureAwait(false); 
             else if (currentversion.StartsWith("3."))
-                Api.InterrogatorTool = ApiHelper.GetSpecialIvsu(Api.GetLogTool34);
+                Api.InterrogatorTool = await ApiHelper.GetSpecialIvsu(Api.GetLogTool34).ConfigureAwait(false);
             else
-                Api.InterrogatorTool = ApiHelper.GetSpecialIvsu(Api.GetLogTool30);
+                Api.InterrogatorTool = await ApiHelper.GetSpecialIvsu(Api.GetLogTool30).ConfigureAwait(false);
             
             ApplicationManager.Instance.Ivsus.Add(Api.InterrogatorTool);
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"
@@ -376,7 +378,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.DriveLetter = DriveLetter;
             ApplicationManager.Instance.Action = "gracenotesremoval";
             ApplicationManager.Instance.SelectedRelease = "Gracenotes Removal";
-            Api.GracenotesRemoval = ApiHelper.GetSpecialIvsu(Api.GetGracenotesRemoval);
+            Api.GracenotesRemoval = ApiHelper.GetSpecialIvsu(Api.GetGracenotesRemoval).GetAwaiter().GetResult();
             ApplicationManager.Instance.Ivsus.Add(Api.GracenotesRemoval);
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"
                 ? "autoinstall"
@@ -399,7 +401,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.Action = "voiceshrinker";
             ApplicationManager.Instance.SelectedRelease = "Voice Package Shrinker";
 
-            Api.SmallVoicePackage = ApiHelper.GetSpecialIvsu(Api.GetSmallVoice);
+            Api.SmallVoicePackage = ApiHelper.GetSpecialIvsu(Api.GetSmallVoice).GetAwaiter().GetResult();
             ApplicationManager.Instance.Ivsus.Add(Api.SmallVoicePackage);
 
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"
@@ -422,7 +424,7 @@ namespace Cyanlabs.Syn3Updater.UI.Tabs
             ApplicationManager.Instance.DriveLetter = DriveLetter;
             ApplicationManager.Instance.Action = "downgrade";
             ApplicationManager.Instance.SelectedRelease = "Enforced Downgrade";
-            Api.DowngradeApp = ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp);
+            Api.DowngradeApp = ApiHelper.GetSpecialIvsu(Api.GetDowngradeApp).GetAwaiter().GetResult();
             ApplicationManager.Instance.Ivsus.Add(Api.DowngradeApp);
 
             ApplicationManager.Instance.InstallMode = ApplicationManager.Instance.Settings.CurrentInstallMode == "autodetect"


### PR DESCRIPTION
- Remove .Result from HttpClient calls by using an AsyncCommand where necessary
- [Deserialize from stream instead of string for performance ](https://www.newtonsoft.com/json/help/html/Performance.htm#MemoryUsage)
- await DoCopy instead creating  a new thread as [filecopy is i/o bound ](https://docs.microsoft.com/en-us/dotnet/csharp/async)